### PR TITLE
Fixes bug causing final word not to be capitalised sometimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.cabal-sandbox
 /cabal.sandbox.config
 /dist
+/dist-newstyle

--- a/src/Data/Text/Titlecase.hs
+++ b/src/Data/Text/Titlecase.hs
@@ -14,7 +14,6 @@ titlecase t = go 1 ws
     ws :: [String]
     ws        = words t
     isFirst i = i == 1
-    isLast  i = i == length ws
 
     go :: Int -> [String] -> String
     go _ []           = ""
@@ -52,7 +51,7 @@ titlecase t = go 1 ws
 
     parse1 i a tt =
       if isOneWordPreposition a || isConjunction a || isArticle a
-      then if isFirst i || isLast i
+      then if isFirst i || null tt
            then toTitle a <#> go (succ i) tt
            else         a <#> go (succ i) tt
       else      toTitle a <#> go (succ i) tt

--- a/tests/Property.hs
+++ b/tests/Property.hs
@@ -22,7 +22,7 @@ ignoreList =
   ++ (fmap unPreposition prepositions)
 
 arbitraryText :: Gen String
-arbitraryText = elements ignoreList
+arbitraryText = unwords <$> listOf (elements ignoreList)
 
 sameLength :: TestTree
 sameLength = testProperty "titlecase doesn't change the length" $


### PR DESCRIPTION
Fixes #4.

This includes changing the property tests to generate and test strings with multiple parts, such as
```haskell
"for atop unlike despite abaft in to like near to unlike up to in addition to inside of such as on account of next to instead of towards afore worth including yet amid qua minus opposite to astride so by means of minus in case of in addition to around in according to amidst vice unto an vs. failing except for owing to next barring outside instead of on behalf of on behalf of as regards as regards up opposite of circa underneath as of an failing besides for including forenenst but"
```
Instead of just testing single prepositions, conjunctions and articles, such as, `"on behalf of"` or `"and"`.

This change causes the `lastWordCapitalized` test to fail. An example of a failing input is `"around despite under as per plus"`.

This is fixed by changing how we recognise the end of the title in `parse1`, switching to `null tt` instead of `isLast i`, which didn't work because the counter isn't properly incremented.

This PR doesn't do any further clean up, but if the use of `isFirst` is removed, then the `go` and `parse*` functions no longer need to pass the `Int` counter around.